### PR TITLE
Podcast addition (epigenetics in the news) 

### DIFF
--- a/02-background_lectures.Rmd
+++ b/02-background_lectures.Rmd
@@ -53,11 +53,4 @@ In [this Nature Podcast Extra](https://www.nature.com/articles/d41586-019-03877-
 
 ## The Effect of lncRNAs on Chromatin and Gene Regulation (John Rinn)
 
-In [this episode](https://activemotif.podbean.com/e/the-effect-of-lncrnas-on-chromatin-and-gene-regulation-john-rinn/) of Epigenetics Podcast, Dr. John Rinn from the University of Colorado in Boulder discusses the role of long noncoding RNAs (lncRNAs) in regulating the expression of genes and chromatin organization.
-
-<iframe id="inlineFrameExample"
-    title="Inline Frame Example"
-    width=95%
-    height=300
-    src="https://activemotif.podbean.com/e/the-effect-of-lncrnas-on-chromatin-and-gene-regulation-john-rinn/">
-</iframe>
+In [this episode of Epigenetics Podcast](https://activemotif.podbean.com/e/the-effect-of-lncrnas-on-chromatin-and-gene-regulation-john-rinn/), Dr. John Rinn from the University of Colorado in Boulder discusses the role of long noncoding RNAs (lncRNAs) in regulating the expression of genes and chromatin organization.

--- a/02-background_lectures.Rmd
+++ b/02-background_lectures.Rmd
@@ -50,3 +50,14 @@ In [this episode](https://sph.umich.edu/podcast/season2/epigenetics.html) of Pop
 ## Exploring the history of epigenetics, and what the future may hold for the field
 
 In [this Nature Podcast Extra](https://www.nature.com/articles/d41586-019-03877-7), Nick Howe speaks to Edith Heard, Director General of the EMBL, and Giacomo Cavalli, from the Institute of Human Genetics, exploring the history and future of epigenetics.
+
+## The Effect of lncRNAs on Chromatin and Gene Regulation (John Rinn)
+
+In [this episode](https://activemotif.podbean.com/e/the-effect-of-lncrnas-on-chromatin-and-gene-regulation-john-rinn/) of Epigenetics Podcast, Dr. John Rinn from the University of Colorado in Boulder discusses the role of long noncoding RNAs (lncRNAs) in regulating the expression of genes and chromatin organization.
+
+<iframe id="inlineFrameExample"
+    title="Inline Frame Example"
+    width=95%
+    height=300
+    src="https://activemotif.podbean.com/e/the-effect-of-lncrnas-on-chromatin-and-gene-regulation-john-rinn/">
+</iframe>

--- a/resources/dictionary.txt
+++ b/resources/dictionary.txt
@@ -20,6 +20,7 @@ euchromatin
 Fibroblasts
 fibroblasts
 Galaxy project
+galaxyproject
 usegalaxy
 GDSCN
 germline
@@ -33,11 +34,13 @@ histone
 HOXA
 impactful
 Kat
+lncRNAs
 lysine
 mentorship
 NCI
 NHGRI
 NHLF
+noncoding
 nucleosome
 nucleosomes
 Onboarding
@@ -45,7 +48,9 @@ OTTR
 ottrpal
 preprint
 RefSeq
+Rinn
 reproducibility
+RNAs
 subtracks
 underserved
 Workspaces


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?

I added John Rinn's podcast per the last discussion. 

#### What was your approach?



#### What GitHub issue does your pull request address?



### Tell potential reviewers what kind of feedback you are soliciting.



### New Content Checklist

- [ ] New content/chapter is in an Rmd file with [this kind of format and headers](https://github.com/jhudsl/OTTR_Template/blob/main/02-chapter_of_course.Rmd).

- [ ] New content/chapter contains [Learning Objectives and are in the correct format](https://github.com/jhudsl/OTTR_Template/wiki/Setting-up-images-and-graphics#learning-objectives-formatting).

- [ ] [Bookdown successfully re-renders and any new content files have been added to the _bookdown.yml](https://github.com/jhudsl/OTTR_Template/wiki/Publishing-with-Bookdown).

- [ ] Spell check runs successfully in [Github actions style-n-check](https://github.com/jhudsl/OTTR_Template/wiki/How-to-set-up-and-customize-GitHub-actions-robots#spell-check)).

- [ ] Any newly necessary packages that are needed have been added to the [Dockerfile and image](https://github.com/jhudsl/OTTR_Template/wiki/Using-Docker#adding-packages-to-the-dockerfile).

- [ ] Images are in the [correct format for rendering](https://github.com/jhudsl/OTTR_Template/wiki/Setting-up-images-and-graphics#adding-images-and-graphics-in-text).

- [ ] Every new image has [alt text and is in a Google Slide](https://github.com/jhudsl/OTTR_Template/wiki/Setting-up-images-and-graphics#accessibility).

- [ ] Each slide is described in the notes of the slide so learners relying on a screen reader can access the content. See https://lastcallmedia.com/blog/accessible-comics for more guidance on this.

- [ ] The color palette choices of the slide are contrasted in a way that is friendly to those with color vision deficiencies.
You can check this using [Color Oracle](https://colororacle.org/).
